### PR TITLE
Merge bobcats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,17 +99,13 @@ lazy val crypto = crossProject(JSPlatform, JVMPlatform)
     name := "http4s-crypto",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % catsVersion,
+      "org.typelevel" %%% "cats-effect-kernel" % catsEffectVersion,
       "org.scodec" %%% "scodec-bits" % scodecBitsVersion,
       "org.scalameta" %%% "munit" % munitVersion % Test,
       "org.typelevel" %%% "cats-laws" % catsVersion % Test,
       "org.typelevel" %%% "cats-effect" % catsEffectVersion % Test,
       "org.typelevel" %%% "discipline-munit" % disciplineMUnitVersion % Test,
       "org.typelevel" %%% "munit-cats-effect-3" % munitCEVersion % Test
-    )
-  )
-  .jsSettings(
-    libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-effect-kernel" % catsEffectVersion
     )
   )
   .dependsOn(testRuntime % Test)

--- a/crypto/jvm/src/main/scala/org/http4s/crypto/CryptoPlatform.scala
+++ b/crypto/jvm/src/main/scala/org/http4s/crypto/CryptoPlatform.scala
@@ -16,10 +16,10 @@
 
 package org.http4s.crypto
 
-import cats.MonadThrow
+import cats.effect.kernel.Sync
 
 private[crypto] trait CryptoCompanionPlatform {
-  implicit def forMonadThrow[F[_]: MonadThrow]: Crypto[F] =
+  implicit def forSync[F[_]: Sync]: Crypto[F] =
     new UnsealedCrypto[F] {
       override def hash: Hash[F] = Hash[F]
       override def hmac: Hmac[F] = Hmac[F]

--- a/crypto/jvm/src/main/scala/org/http4s/crypto/HmacPlatform.scala
+++ b/crypto/jvm/src/main/scala/org/http4s/crypto/HmacPlatform.scala
@@ -16,7 +16,7 @@
 
 package org.http4s.crypto
 
-import cats.ApplicativeThrow
+import cats.effect.kernel.Sync
 import scodec.bits.ByteVector
 import javax.crypto
 
@@ -25,7 +25,7 @@ private[crypto] trait HmacPlatform[F[_]] {
 }
 
 private[crypto] trait HmacCompanionPlatform {
-  implicit def forApplicativeThrow[F[_]](implicit F: ApplicativeThrow[F]): Hmac[F] =
+  implicit def forSync[F[_]](implicit F: Sync[F]): Hmac[F] =
     new UnsealedHmac[F] {
 
       override def digest(key: SecretKey[HmacAlgorithm], data: ByteVector): F[ByteVector] =
@@ -38,7 +38,7 @@ private[crypto] trait HmacCompanionPlatform {
         }
 
       override def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]] =
-        F.catchNonFatal {
+        F.delay {
           val key = crypto.KeyGenerator.getInstance(algorithm.toStringJava).generateKey()
           SecretKeySpec(ByteVector.view(key.getEncoded()), algorithm)
         }


### PR DESCRIPTION
Brings in https://github.com/typelevel/bobcats/pull/13.

Note that this adds a CE3 dependency to JVM, which breaks compatibility with http4s 0.22. I was overly optimistic that we could avoid this.