### PR TITLE
Extract `HmacKeyGen` from `Hmac`

### DIFF
--- a/crypto/js/src/main/scala/org/http4s/crypto/CryptoPlatform.scala
+++ b/crypto/js/src/main/scala/org/http4s/crypto/CryptoPlatform.scala
@@ -24,5 +24,6 @@ private[crypto] trait CryptoCompanionPlatform {
     new UnsealedCrypto[F] {
       override def hash: Hash[F] = Hash[F]
       override def hmac: Hmac[F] = Hmac[F]
+      override def hmacKeyGen: HmacKeyGen[F] = HmacKeyGen[F]
     }
 }

--- a/crypto/js/src/main/scala/org/http4s/crypto/HmacKeyGenPlatform.scala
+++ b/crypto/js/src/main/scala/org/http4s/crypto/HmacKeyGenPlatform.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.crypto
+
+import cats.effect.kernel.Async
+import cats.effect.kernel.Sync
+import cats.syntax.all._
+import scodec.bits.ByteVector
+
+import scala.scalajs.js
+
+private[crypto] trait HmacKeyGenCompanionPlatform {
+  implicit def forAsyncOrSync[F[_]](implicit F0: Priority[Async[F], Sync[F]]): HmacKeyGen[F] =
+    if (facade.isNodeJSRuntime)
+      new UnsealedHmacKeyGen[F] {
+        import facade.node._
+
+        override def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]] =
+          F0.fold { F =>
+            F.async_[SecretKey[A]] { cb =>
+              crypto.generateKey(
+                "hmac",
+                GenerateKeyOptions(algorithm.minimumKeyLength),
+                (err, key) =>
+                  cb(
+                    Option(err)
+                      .map(js.JavaScriptException)
+                      .toLeft(SecretKeySpec(ByteVector.view(key.`export`()), algorithm)))
+              )
+            }
+          } { F =>
+            F.delay {
+              val key =
+                crypto.generateKeySync("hmac", GenerateKeyOptions(algorithm.minimumKeyLength))
+              SecretKeySpec(ByteVector.view(key.`export`()), algorithm)
+            }
+          }
+
+      }
+    else
+      F0.getPreferred
+        .map { implicit F: Async[F] =>
+          new UnsealedHmacKeyGen[F] {
+            import facade.browser._
+            override def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]] =
+              for {
+                key <- F.fromPromise(
+                  F.delay(
+                    crypto
+                      .subtle
+                      .generateKey(
+                        HmacKeyGenParams(algorithm.toStringWebCrypto),
+                        true,
+                        js.Array("sign"))))
+                exported <- F.fromPromise(F.delay(crypto.subtle.exportKey("raw", key)))
+              } yield SecretKeySpec(ByteVector.view(exported), algorithm)
+          }
+        }
+        .getOrElse(throw new UnsupportedOperationException(
+          "HmacKeyGen[F] on browsers requires Async[F]"))
+
+}

--- a/crypto/shared/src/main/scala/org/http4s/crypto/Crypto.scala
+++ b/crypto/shared/src/main/scala/org/http4s/crypto/Crypto.scala
@@ -19,6 +19,7 @@ package org.http4s.crypto
 private[http4s] sealed trait Crypto[F[_]] {
   def hash: Hash[F]
   def hmac: Hmac[F]
+  def hmacKeyGen: HmacKeyGen[F]
 }
 
 private[crypto] trait UnsealedCrypto[F[_]] extends Crypto[F]

--- a/crypto/shared/src/main/scala/org/http4s/crypto/Hmac.scala
+++ b/crypto/shared/src/main/scala/org/http4s/crypto/Hmac.scala
@@ -20,7 +20,6 @@ import scodec.bits.ByteVector
 
 private[http4s] sealed trait Hmac[F[_]] extends HmacPlatform[F] {
   def digest(key: SecretKey[HmacAlgorithm], data: ByteVector): F[ByteVector]
-  def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]]
   def importKey[A <: HmacAlgorithm](key: ByteVector, algorithm: A): F[SecretKey[A]]
 }
 

--- a/crypto/shared/src/main/scala/org/http4s/crypto/HmacKeyGen.scala
+++ b/crypto/shared/src/main/scala/org/http4s/crypto/HmacKeyGen.scala
@@ -16,13 +16,14 @@
 
 package org.http4s.crypto
 
-import cats.effect.kernel.Sync
+private[http4s] sealed trait HmacKeyGen[F[_]] {
+  def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]]
+}
 
-private[crypto] trait CryptoCompanionPlatform {
-  implicit def forSync[F[_]: Sync]: Crypto[F] =
-    new UnsealedCrypto[F] {
-      override def hash: Hash[F] = Hash[F]
-      override def hmac: Hmac[F] = Hmac[F]
-      override def hmacKeyGen: HmacKeyGen[F] = HmacKeyGen[F]
-    }
+private[crypto] trait UnsealedHmacKeyGen[F[_]] extends HmacKeyGen[F]
+
+private[http4s] object HmacKeyGen extends HmacKeyGenCompanionPlatform {
+
+  def apply[F[_]](implicit hkg: HmacKeyGen[F]): hkg.type = hkg
+
 }

--- a/crypto/shared/src/test/scala/org/http4s/crypto/HmacSuite.scala
+++ b/crypto/shared/src/test/scala/org/http4s/crypto/HmacSuite.scala
@@ -43,7 +43,7 @@ class HmacSuite extends CatsEffectSuite {
 
   final def testGenerateKey(algorithm: HmacAlgorithm) =
     test(s"generate key for ${algorithm}") {
-      Hmac[IO].generateKey(algorithm).map {
+      HmacKeyGen[IO].generateKey(algorithm).map {
         case SecretKeySpec(key, keyAlgorithm) =>
           assertEquals(algorithm, keyAlgorithm)
           assert(key.size >= algorithm.minimumKeyLength)


### PR DESCRIPTION
I'm not crazy about this, so only making the change for http4s-crypto and not running it through bobcats.

The purpose of this change is to isolate the strong constraint needed to generate keys (`Sync`) from the weaker constraint needed to compute the digest (`ApplicativeThrow`). This only applies to JVM and Node.js platforms (browsers are `Async` all the way).

This lets us compute digests in http4s where we only have `MonadThrow` available, such as the client oauth helpers.

I look forward to one day when this is all stable and we can just request a `Crypto[F]` constraint or similar and be done with it.