### PR TITLE
Explicitly use JDK8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.1.0, 2.12.15, 2.13.7]
-        java: [temurin@11]
+        java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -35,12 +35,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
 
       - name: Cache sbt
         uses: actions/cache@v2
@@ -81,7 +81,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.7]
-        java: [temurin@11]
+        java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -89,12 +89,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,8 @@ ThisBuild / scmInfo := Some(
 
 ThisBuild / crossScalaVersions := Seq("3.1.0", "2.12.15", "2.13.7")
 
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"))
+
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Use(
     UseRef.Public("actions", "setup-node", "v2.4.0"),


### PR DESCRIPTION
I didn't realize the new default in sbt-gh-actions is JDK 11, which can be Trouble.