### PR TITLE
Deprecate `Priority`

### DIFF
--- a/crypto/js/src/main/scala/org/http4s/crypto/CryptoPlatform.scala
+++ b/crypto/js/src/main/scala/org/http4s/crypto/CryptoPlatform.scala
@@ -20,7 +20,12 @@ import cats.effect.kernel.Async
 import cats.effect.kernel.Sync
 
 private[crypto] trait CryptoCompanionPlatform {
-  implicit def forAsyncOrSync[F[_]](implicit F: Priority[Async[F], Sync[F]]): Crypto[F] =
+
+  @deprecated("Preserved for bincompat", "0.2.3")
+  def forAsyncOrSync[F[_]](implicit F: Priority[Async[F], Sync[F]]): Crypto[F] =
+    forSync(F.join)
+
+  implicit def forSync[F[_]](implicit F: Sync[F]): Crypto[F] =
     new UnsealedCrypto[F] {
       override def hash: Hash[F] = Hash[F]
       override def hmac: Hmac[F] = Hmac[F]

--- a/crypto/js/src/main/scala/org/http4s/crypto/HmacKeyGenPlatform.scala
+++ b/crypto/js/src/main/scala/org/http4s/crypto/HmacKeyGenPlatform.scala
@@ -37,13 +37,13 @@ private[crypto] trait HmacKeyGenCompanionPlatform {
           Some(F)
             .collect { case f: Async[F] => f }
             .fold {
-              F.delay {
+              F.delay[SecretKey[A]] {
                 val key =
                   crypto.generateKeySync("hmac", GenerateKeyOptions(algorithm.minimumKeyLength))
                 SecretKeySpec(ByteVector.view(key.`export`()), algorithm)
               }
             } { F =>
-              F.async_ { cb =>
+              F.async_[SecretKey[A]] { cb =>
                 crypto.generateKey(
                   "hmac",
                   GenerateKeyOptions(algorithm.minimumKeyLength),
@@ -55,7 +55,6 @@ private[crypto] trait HmacKeyGenCompanionPlatform {
                 )
               }
             }
-            .widen
 
       }
     else

--- a/crypto/js/src/main/scala/org/http4s/crypto/HmacKeyGenPlatform.scala
+++ b/crypto/js/src/main/scala/org/http4s/crypto/HmacKeyGenPlatform.scala
@@ -24,36 +24,46 @@ import scodec.bits.ByteVector
 import scala.scalajs.js
 
 private[crypto] trait HmacKeyGenCompanionPlatform {
-  implicit def forAsyncOrSync[F[_]](implicit F0: Priority[Async[F], Sync[F]]): HmacKeyGen[F] =
+  @deprecated("Preserved for bincompat", "0.2.3")
+  def forAsyncOrSync[F[_]](implicit F0: Priority[Async[F], Sync[F]]): HmacKeyGen[F] =
+    forSync(F0.join)
+
+  implicit def forSync[F[_]](implicit F: Sync[F]): HmacKeyGen[F] =
     if (facade.isNodeJSRuntime)
       new UnsealedHmacKeyGen[F] {
         import facade.node._
 
         override def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]] =
-          F0.fold { F =>
-            F.async_[SecretKey[A]] { cb =>
-              crypto.generateKey(
-                "hmac",
-                GenerateKeyOptions(algorithm.minimumKeyLength),
-                (err, key) =>
-                  cb(
-                    Option(err)
-                      .map(js.JavaScriptException)
-                      .toLeft(SecretKeySpec(ByteVector.view(key.`export`()), algorithm)))
-              )
+          Some(F)
+            .collect { case f: Async[F] => f }
+            .fold {
+              F.delay {
+                val key =
+                  crypto.generateKeySync("hmac", GenerateKeyOptions(algorithm.minimumKeyLength))
+                SecretKeySpec(ByteVector.view(key.`export`()), algorithm)
+              }
+            } { F =>
+              F.async_ { cb =>
+                crypto.generateKey(
+                  "hmac",
+                  GenerateKeyOptions(algorithm.minimumKeyLength),
+                  (err, key) =>
+                    cb(
+                      Option(err)
+                        .map(js.JavaScriptException)
+                        .toLeft(SecretKeySpec(ByteVector.view(key.`export`()), algorithm)))
+                )
+              }
             }
-          } { F =>
-            F.delay {
-              val key =
-                crypto.generateKeySync("hmac", GenerateKeyOptions(algorithm.minimumKeyLength))
-              SecretKeySpec(ByteVector.view(key.`export`()), algorithm)
-            }
-          }
+            .widen
 
       }
     else
-      F0.getPreferred
-        .map { implicit F: Async[F] =>
+      Some(F)
+        .collect { case f: Async[F] => f }
+        .fold(
+          throw new UnsupportedOperationException("HmacKeyGen[F] on browsers requires Async[F]")
+        ) { implicit F =>
           new UnsealedHmacKeyGen[F] {
             import facade.browser._
             override def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]] =
@@ -70,7 +80,5 @@ private[crypto] trait HmacKeyGenCompanionPlatform {
               } yield SecretKeySpec(ByteVector.view(exported), algorithm)
           }
         }
-        .getOrElse(throw new UnsupportedOperationException(
-          "HmacKeyGen[F] on browsers requires Async[F]"))
 
 }

--- a/crypto/js/src/main/scala/org/http4s/crypto/Priority.scala
+++ b/crypto/js/src/main/scala/org/http4s/crypto/Priority.scala
@@ -26,6 +26,7 @@ package org.http4s.crypto
  * This type can be useful for problems where multiple algorithms can be used, depending on the
  * type classes available.
  */
+@deprecated("Unneeded when P and F belong to the same hiearchy", "0.2.3")
 private[http4s] sealed trait Priority[+P, +F] {
 
   import Priority.{Fallback, Preferred}
@@ -70,11 +71,13 @@ private[http4s] object Priority extends FindPreferred {
 }
 
 private[crypto] trait FindPreferred extends FindFallback {
-  implicit def preferred[P](implicit ev: P): Priority[P, Nothing] =
+  @deprecated("Priority is deprecated", "0.2.3")
+  def preferred[P](implicit ev: P): Priority[P, Nothing] =
     Priority.Preferred(ev)
 }
 
 private[crypto] trait FindFallback {
-  implicit def fallback[F](implicit ev: F): Priority[Nothing, F] =
+  @deprecated("Priority is deprecated", "0.2.3")
+  def fallback[F](implicit ev: F): Priority[Nothing, F] =
     Priority.Fallback(ev)
 }


### PR DESCRIPTION
Adopts the `isInstanceOf` pattern from Cats Effect and deprecates `Priority`. They are doing the same thing at the type-level. But now in situations where we can't acquire an `Async` instance at the type-level (due to our inability to appropriately strengthen the constraint bin- and source-compatibility in http4s) we can still provide an implementation if at runtime the instance is indeed `Async` as it very often is. So this is a big win.